### PR TITLE
Replace per-byte read timeout with bytesWaitingRx-poll

### DIFF
--- a/AstroTrac.cpp
+++ b/AstroTrac.cpp
@@ -186,14 +186,18 @@ int AstroTrac::AstroTracSendCommand(const char *pszCmd, char *pszResult, unsigne
     for (itries = 0; itries < MAXSENDTRIES; itries++) {
         nErr = AstroTracSendCommandInnerLoop(pszCmd, pszResult, nResultMaxLen, itries > 0);
         if (nErr == PLUGIN_OK) {
-            // Only log the ones that needed a retry - this is the total time from the first send
-            // attempt to a working reply, which is what a longer read timeout would need to beat.
-            if (itries > 0) {
-                clock_gettime(CLOCK_MONOTONIC, &cmdNow);
-                double cmdElapsed = (cmdNow.tv_sec - cmdStart.tv_sec) + (cmdNow.tv_nsec - cmdStart.tv_nsec) * 1e-9;
+            clock_gettime(CLOCK_MONOTONIC, &cmdNow);
+            double cmdElapsed = (cmdNow.tv_sec - cmdStart.tv_sec) + (cmdNow.tv_nsec - cmdStart.tv_nsec) * 1e-9;
+            if (itries > 0)
+                // Notable - this is the total time from the first send attempt to a working
+                // reply, which is what a longer read timeout would need to beat.
                 LogDebug(1, "AstroTrac::AstroTracSendCommand Cmd: %s succeeded after %d retries, %.3f seconds total\n",
                          pszCmd, itries, cmdElapsed);
-            }
+            else
+                // Routine (first-try success, the common case) - only useful in bulk, e.g. to
+                // build a distribution of normal round-trip timing, so kept off level 1.
+                LogDebug(2, "AstroTrac::AstroTracSendCommand Cmd: %s succeeded first try, %.3f seconds total\n",
+                         pszCmd, cmdElapsed);
             return nErr;
         }
 
@@ -423,45 +427,69 @@ bool AstroTrac::responseMatchesCommand(const char *pszCmd, const unsigned char *
     return false;
 }
 
+// Poll bytesWaitingRx and only call readFile once bytes are actually confirmed present, reading
+// whatever's waiting in one call rather than one byte at a time. Timeout is self-managed (sleep
+// READ_POLL_INTERVAL_MS between polls, up to MAX_TIMEOUT total) rather than relying on readFile's
+// or waitForBytesRx's own timeout, which earlier testing found doesn't reliably honor the value
+// requested. Ported from the read-loop approach in the old Development branch (deviceCommand /
+// readResponse there), minus its std::string signature - the existing char*-buffer API is kept.
 int AstroTrac::AstroTracreadResponse(unsigned char *pszRespBuffer, unsigned int nBufferLen)
 {
     int nErr = PLUGIN_OK;
     unsigned long ulBytesRead = 0;
     unsigned long ulTotalBytesRead = 0;
     unsigned char *pszBufPtr;
+    int nMsWaited = 0;
+#if defined PLUGIN_DEBUG && PLUGIN_DEBUG >= 0
+    struct timespec rfStart, rfEnd;
+    clock_gettime(CLOCK_MONOTONIC, &rfStart);
+#endif
 
     memset(pszRespBuffer, 0, (size_t) nBufferLen);
     pszBufPtr = pszRespBuffer;
 
     do {
+        int nBytesWaiting = 0;
+        int nErrPeek = m_pSerx->bytesWaitingRx(nBytesWaiting);
+
+        if (nErrPeek || nBytesWaiting <= 0) {
+            if (nMsWaited >= (int)MAX_TIMEOUT) {
 #if defined PLUGIN_DEBUG && PLUGIN_DEBUG >= 0
-        struct timespec rfStart, rfEnd;
-        clock_gettime(CLOCK_MONOTONIC, &rfStart);
+                clock_gettime(CLOCK_MONOTONIC, &rfEnd);
+                double rfElapsed = (rfEnd.tv_sec - rfStart.tv_sec) + (rfEnd.tv_nsec - rfStart.tv_nsec) * 1e-9;
+                LogDebug(1, "[AstroTrac::readResponse] TIMED OUT: no bytes waiting after %.3f seconds (of %dms requested timeout, had %lu byte(s) so far: '%s')\n",
+                         rfElapsed, MAX_TIMEOUT, ulTotalBytesRead, pszRespBuffer);
 #endif
-        nErr = m_pSerx->readFile(pszBufPtr, 1, ulBytesRead, MAX_TIMEOUT);
-        if(nErr || ulBytesRead != 1) {
-#if defined PLUGIN_DEBUG && PLUGIN_DEBUG >= 0
-            clock_gettime(CLOCK_MONOTONIC, &rfEnd);
-            double rfElapsed = (rfEnd.tv_sec - rfStart.tv_sec) + (rfEnd.tv_nsec - rfStart.tv_nsec) * 1e-9;
-            if (nErr)
-                LogDebug(2, "[AstroTrac::readResponse] readFile error %d after %.3f seconds (had %lu byte(s) so far: '%s')\n",
-                         nErr, rfElapsed, ulTotalBytesRead, pszRespBuffer);
-            else
-                LogDebug(2, "[AstroTrac::readResponse] readFile got %lu byte(s) (wanted 1) after %.3f seconds (had %lu byte(s) so far: '%s')\n",
-                         ulBytesRead, rfElapsed, ulTotalBytesRead, pszRespBuffer);
-#endif
-            if (nErr) return nErr;
+                return PLUGIN_BAD_CMD_RESPONSE;
+            }
+            if (m_pSleeper)
+                m_pSleeper->sleep(READ_POLL_INTERVAL_MS);
+            nMsWaited += READ_POLL_INTERVAL_MS;
+            continue;
         }
 
-        LogDebug(3, "[AstroTrac::readResponse] *pszBufPtr = 0x%02X ulBytesRead %d\n", *pszBufPtr, ulBytesRead);
+        // Read whatever's waiting in one call, bounded by remaining buffer space.
+        unsigned long ulToRead = (unsigned long)nBytesWaiting;
+        if (ulTotalBytesRead + ulToRead > nBufferLen)
+            ulToRead = nBufferLen - ulTotalBytesRead;
 
-        if (ulBytesRead != 1) {// timeout
-            nErr = PLUGIN_BAD_CMD_RESPONSE;
-	    return nErr;
+        nErr = m_pSerx->readFile(pszBufPtr, ulToRead, ulBytesRead, MAX_TIMEOUT);
+        if (nErr) {
+            LogDebug(1, "[AstroTrac::readResponse] readFile error %d reading %lu waiting byte(s) (had %lu byte(s) so far: '%s')\n",
+                     nErr, ulToRead, ulTotalBytesRead, pszRespBuffer);
+            return nErr;
         }
+        if (ulBytesRead != ulToRead)
+            LogDebug(1, "[AstroTrac::readResponse] readFile got %lu byte(s), bytesWaitingRx had reported %lu waiting (had %lu byte(s) so far: '%s')\n",
+                     ulBytesRead, ulToRead, ulTotalBytesRead, pszRespBuffer);
+
+        LogDebug(2, "[AstroTrac::readResponse] bytesWaitingRx=%d, read %lu byte(s)\n", nBytesWaiting, ulBytesRead);
+
+        nMsWaited = 0;
         ulTotalBytesRead += ulBytesRead;
+        pszBufPtr += ulBytesRead;
 
-    } while (*pszBufPtr++ != '>' && ulTotalBytesRead < nBufferLen );
+    } while ((ulTotalBytesRead == 0 || *(pszBufPtr - 1) != '>') && ulTotalBytesRead < nBufferLen);
 
 
     // Last character should be a '>' - if not send error message

--- a/AstroTrac.cpp
+++ b/AstroTrac.cpp
@@ -301,14 +301,26 @@ int AstroTrac::WriteCommand(const char *pszCmd)
 {
     int nErr;
     unsigned long ulBytesWrite;
+#if defined PLUGIN_DEBUG && PLUGIN_DEBUG >= 0
+    struct timespec wcStart, wcEnd;
+    clock_gettime(CLOCK_MONOTONIC, &wcStart);
+#endif
 
     LogDebug(2, "[AstroTrac::AstroTracSendCommandInnerLoop] Sending %s\n", pszCmd);
 
     nErr = m_pSerx->writeFile((void *)pszCmd, strlen(pszCmd), ulBytesWrite);
     m_pSerx->flushTx();
 
+#if defined PLUGIN_DEBUG && PLUGIN_DEBUG >= 0
+    {
+        clock_gettime(CLOCK_MONOTONIC, &wcEnd);
+        double wcElapsed = (wcEnd.tv_sec - wcStart.tv_sec) + (wcEnd.tv_nsec - wcStart.tv_nsec) * 1e-9;
+        LogDebug(2, "[AstroTrac::WriteCommand] writeFile+flushTx for Cmd: %s took %.3f seconds\n", pszCmd, wcElapsed);
+    }
+#endif
+
     if (nErr)
-        LogDebug(2, "[AstroTrac::AstroTracSendCommandInnerLooop] error %d sending command : %s\n", nErr, pszCmd);
+        LogDebug(1, "[AstroTrac::WriteCommand] error %d sending command : %s\n", nErr, pszCmd);
 
     return nErr;
 }

--- a/AstroTrac.h
+++ b/AstroTrac.h
@@ -35,14 +35,16 @@
 //   1: Notable/unexpected events worth a heads-up even outside active debugging - command outcome
 //      summaries (succeeded after N retries / FAILED), a malformed device error reply, an
 //      unexpectedly-mismatched extra reply, a response missing its closing '>', a read that timed
-//      out waiting for bytes (with elapsed time), or fewer bytes read than bytesWaitingRx reported.
+//      out waiting for bytes (with elapsed time), fewer bytes read than bytesWaitingRx reported, or
+//      a writeFile error sending a command.
 //   2: Full trace of the send-command machinery (AstroTracSendCommand/AstroTracSendCommandInnerLoop/
 //      readResponse) - purge/resend decisions, stale/duplicate-reply draining, each batch of bytes
-//      read in readResponse, and every first-try-success command's round-trip time (for building a
-//      timing distribution - the level 1 "succeeded after N retries" line only covers retried ones).
-//      Only useful when actively debugging the comms protocol itself.
+//      read in readResponse, how long WriteCommand's writeFile+flushTx took to send each command,
+//      and every first-try-success command's round-trip time (for building a timing distribution -
+//      the level 1 "succeeded after N retries" line only covers retried ones). Only useful when
+//      actively debugging the comms protocol itself.
 //   3: Everything else - connection lifecycle, coordinate/math tracing, slew lifecycle.
-#define PLUGIN_DEBUG 1
+// #define PLUGIN_DEBUG 2
 #define DRIVER_VERSION 1.7
 
 // Changelog:

--- a/AstroTrac.h
+++ b/AstroTrac.h
@@ -42,7 +42,7 @@
 //      timing distribution - the level 1 "succeeded after N retries" line only covers retried ones).
 //      Only useful when actively debugging the comms protocol itself.
 //   3: Everything else - connection lifecycle, coordinate/math tracing, slew lifecycle.
-#define PLUGIN_DEBUG 2
+#define PLUGIN_DEBUG 1
 #define DRIVER_VERSION 1.7
 
 // Changelog:

--- a/AstroTrac.h
+++ b/AstroTrac.h
@@ -34,13 +34,15 @@
 //   0: Open-loop-move tracing (startOpenLoopMove/stopOpenLoopMove) - relevant to guiding performance.
 //   1: Notable/unexpected events worth a heads-up even outside active debugging - command outcome
 //      summaries (succeeded after N retries / FAILED), a malformed device error reply, an
-//      unexpectedly-mismatched extra reply, a response missing its closing '>'.
+//      unexpectedly-mismatched extra reply, a response missing its closing '>', a read that timed
+//      out waiting for bytes (with elapsed time), or fewer bytes read than bytesWaitingRx reported.
 //   2: Full trace of the send-command machinery (AstroTracSendCommand/AstroTracSendCommandInnerLoop/
-//      readResponse) - purge/resend decisions, stale/duplicate-reply draining, per-byte read
-//      timeouts. Only useful when actively debugging the comms protocol itself.
-//   3: Everything else - connection lifecycle, coordinate/math tracing, slew lifecycle, byte-level
-//      read trace.
-// #define PLUGIN_DEBUG 0
+//      readResponse) - purge/resend decisions, stale/duplicate-reply draining, each batch of bytes
+//      read in readResponse, and every first-try-success command's round-trip time (for building a
+//      timing distribution - the level 1 "succeeded after N retries" line only covers retried ones).
+//      Only useful when actively debugging the comms protocol itself.
+//   3: Everything else - connection lifecycle, coordinate/math tracing, slew lifecycle.
+#define PLUGIN_DEBUG 2
 #define DRIVER_VERSION 1.7
 
 // Changelog:
@@ -64,12 +66,16 @@
 enum AstroTracErrors {PLUGIN_OK=0, NOT_CONNECTED, PLUGIN_CANT_CONNECT, PLUGIN_BAD_CMD_RESPONSE, COMMAND_FAILED, PLUGIN_ERROR};
 
 #define SERIAL_BUFFER_SIZE 256
-#define MAX_TIMEOUT 100
+#define MAX_TIMEOUT 300
 #define PLUGIN_LOG_BUFFER_SIZE 256
 #define ERR_PARSE   1
 
 #define MAXSENDTRIES 3  // Maximum number of attempts to send a mesage to the mount
 #define MAX_STALE_RESPONSE_TRIES 2  // Maximum number of stray/stale replies to discard while looking for the real response to a command
+// 3ms was picked from measurement: at 25ms polling, replies clustered almost entirely in the
+// first one or two poll windows; dropping to 3ms revealed the true round-trip is ~2-9ms for the
+// overwhelming majority of commands, with no sign of a coarser scheduler floor forcing it back up.
+#define READ_POLL_INTERVAL_MS 3  // How often AstroTracreadResponse re-checks bytesWaitingRx while waiting for a reply
 
 
 // Define Class for Astrometric Instruments AstroTrac controller.


### PR DESCRIPTION
## Summary
- Replace `AstroTracreadResponse`'s per-byte `readFile(..., 1, ...)` loop (relying on readFile's own unreliable timeout) with polling `bytesWaitingRx` and reading whatever's waiting in one batch, timing itself out via a self-managed sleep/poll loop instead. Ported from the old `Development` branch's read-loop approach, keeping the existing char*-buffer API rather than its std::string signature.
- Add write-side timing (`WriteCommand`'s `writeFile`+`flushTx`) and a level-2 round-trip timing log for every first-try-successful command, so normal traffic can be measured, not just failures.
- `MAX_TIMEOUT` 100 -> 300ms and `READ_POLL_INTERVAL_MS` 25 -> 3ms, both set from real hardware measurement (see below), not guesswork.
- `PLUGIN_DEBUG` left disabled (commented out), matching production convention.

## Why
Empirical testing (hundreds of thousands of real commands against the mount, across several hardware runs) found:
- The write side is essentially always instant (median/p95 0ms, max ever seen 22ms) - all the interesting timing variation is on the read/wait side.
- At the old 25ms poll interval, ~100% of traffic landed in a single 25-26ms bucket - almost entirely our own polling granularity, not real mount latency. At 3ms, the true round-trip is ~2-9ms for 99.6% of commands, with no sign of a coarser scheduler floor forcing it back up.
- A specific, repeatable ~200-227ms reply pattern needed 2 full 100ms timeout cycles to resolve; 300ms gives it room to succeed in one attempt (occurred in ~0.02% of commands).
- That same ~200ms pattern also correlated with the Pi's TCP `rto_min` kernel setting (200ms default) - dropping `rto_min` to 20ms cut its frequency by ~8-10x and its magnitude down to under 60ms, strongly suggesting it was a TCP retransmission-timeout artifact rather than anything in the driver or firmware.

## Test plan
- [x] Builds clean, no new warnings.
- [x] ~700k+ commands across multiple real hardware runs (varying `MAX_TIMEOUT`, `READ_POLL_INTERVAL_MS`, Pi `rto_min`, and TheSkyX's own mount-poll interval) - 0 retries, 0 timeouts, 0 failures in the longest runs at the final settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)