### PR TITLE
Bump to 2.0, add Key changes section, and polish README

### DIFF
--- a/AstroTrac.h
+++ b/AstroTrac.h
@@ -45,7 +45,7 @@
 //      actively debugging the comms protocol itself.
 //   3: Everything else - connection lifecycle, coordinate/math tracing, slew lifecycle.
 // #define PLUGIN_DEBUG 2
-#define DRIVER_VERSION 1.7
+#define DRIVER_VERSION 2.0
 
 // Changelog:
 // Version  1.0: Initial release
@@ -58,6 +58,11 @@
 //          1.7: Added horizon limit setting, and send both it and the meridian/latitude settings to the mount
 //               firmware (>= 2.35) as a last-resort backstop, padded with FIRMWARE_SAFETY_MARGIN_DEG so this
 //               driver's own meridian/horizon checks in raDec() still take precedence.
+//          2.0: Audited and fixed mutex coverage around every call into AstroTrac.cpp, including a reentrant-locking
+//               deadlock risk. Rewrote the read path (AstroTracreadResponse) to poll bytesWaitingRx and batch-read
+//               instead of relying on readFile's unreliable per-byte timeout, and tuned the retry/timeout constants
+//               from measured hardware data. Added the firmware-level post-meridian/horizon safety backstop
+//               (see 1.7) as the headline new capability.
 
 
 #define AT_SIDEREAL_SPEED 15.04106864 // Arc sec/s required to maintain siderial tracking

--- a/README.md
+++ b/README.md
@@ -1,61 +1,73 @@
 # AstroTrac X2 Driver
 
-An X2 plugin for controlling an AstroTrac360 mount from TheSkyX, connecting over
-TCP/IP (typically to a mount reachable over Wi-Fi, e.g. via a Raspberry Pi bridge).
+An X2 plugin for controlling an AstroTrac360 mount from TheSky.
+
+## Key changes in 2.0
+
+- **More robust, better-optimised communication with the mount.** Fixed a
+  reentrant-locking deadlock risk in the mutex coverage around every call into
+  the mount communication layer. Replaced the unreliable per-byte read timeout
+  with a poll-and-batch-read approach, and tuned the retry/timeout constants
+  from measured hardware data - see the recommendations below for further
+  steps you can take to improve reliability.
+- **Firmware-level post-meridian and horizon safety backstop.** The driver can
+  now send its meridian and horizon safety limits to the mount firmware
+  (2.35 and later) as a backstop, so tracking still stops safely even if TheSky 
+  hangs or the connection to the mount is lost. See **Driver settings** below.
 
 ## Connecting to the mount
 
-TheSkyX's own serial-device dialog is used to point the driver at the mount, even
+TheSky's serial-device dialog is used to point the driver at the mount, even
 though the connection is actually TCP/IP rather than a physical serial port:
 
 ![Serial Device Settings dialog](docs/images/serial-device-settings.png)
 
 - **Serial device**: set to `TCP/IP`.
 - **TCP/IP host**: the mount's IP address on your network. **Replace the example
-  address shown here with your own mount's actual IP** - every network is
-  different, and using the wrong address will simply fail to connect.
-- **TCP/IP port**: `23` (matches the AstroTrac's own control port).
+  address shown here with your own mount's actual IP** - your AstroTrac360 generates
+  its own unique IP address, derived from its Wi-Fi chip's MAC address.
+- **TCP/IP port**: `23` (this is the AstroTrac360's control port).
 
 These settings can only be changed while disconnected - click **Cancel** first if
-TheSkyX is currently connected to the mount.
+TheSky is currently connected to the mount.
+
+Click **More Settings...** in this same dialog to open the driver's own settings
+(below).
 
 ## Driver settings
 
-The driver's own settings dialog (Tools -> AstroTrac360 Setup, or similar,
-depending on how TheSkyX exposes it):
+Reached via **More Settings...** in the Serial Device Settings dialog above:
 
 ![AstroTrac360 Setup dialog](docs/images/astrotrac360-setup.png)
 
 - **Hours tracking past Meridian**: how long the mount is allowed to keep
   tracking past the meridian before the driver stops it. This is a software
-  safety limit enforced in the driver's own `raDec()` polling; a padded version
-  of the same limit is also sent to the mount firmware (2.35 and later) as a
-  last-resort backstop, in case TheSkyX itself hangs or the connection drops
-  before the driver's own check can act.
+  safety limit enforced in the driver. The driver will also set a firmware limit
+  (firmware 2.35 and later) as a backstop in case TheSky hangs or the connection
+  to the mount fails. The firmware backstop will operate 12 minutes after
+  the driver should act.
 - **Horizon limit (degrees altitude)**: the altitude below which the driver
-  stops tracking, enforced the same way - driver-side check first, with a
-  padded firmware-side backstop behind it.
+  stops tracking, enforced the same way. The X2 driver should operate first, with
+  a firmware backstop set 3 degrees lower.
 - **Pulse Guide Rate**: the guide rate (as a fraction of sidereal) used for
-  autoguiding pulses sent via `PulseGuide`/`OpenLoopMove`. `0.1x` is a
-  reasonable default for most setups; TheSkyX's own guiding documentation
-  covers when a different rate is appropriate.
+  autoguiding pulses sent via `PulseGuide`/`OpenLoopMove`. `0.1x` is recommended
+  by Richard Taylor who designed AstroTrac360 - note that you will need a longer
+  guiding calibration time (25 seconds) to get sufficient movement for a good
+  calibration.
 
-## Reducing an occasional ~200ms guide-pulse stall (Raspberry Pi bridge setups)
+## Recommended: reduce retransmission timeout on a Raspberry Pi
 
-If the mount is reached over Wi-Fi via a Raspberry Pi (or similar Linux bridge),
-you may see an occasional command take noticeably longer than normal to
-complete - repeatable, isolated events landing consistently around 200-220ms,
-distinct from the mount's normal ~2-9ms response time. Driver-side logging and
-testing traced this to Linux's TCP `rto_min` (minimum retransmission timeout)
-setting, which defaults to 200ms - if a packet to or from the mount is ever
-lost, the kernel won't retry sooner than that, regardless of the actual
-round-trip time on the link.
+When tested on a Raspberry Pi 5, more than 99.9% of commands to the mount were 
+transmitted in less than 10ms. However, if there was a problem and a data packet
+had to be re-transmitted, there were delays of 220ms. This is because the 
+Raspberry Pi 5 has a default re-transmission time of 200ms. Lowering this limit
+to 20ms reduced the number of times this happened by a factor of 10. Combined
+with setting the cross hair update interval below, the maximum delay was reduced to 50ms.
 
-Lowering `rto_min` for the route to the mount reduced both how often this
-happened (roughly 8-10x fewer occurrences) and how long it lasted when it did
-(down from a tight ~207-227ms band to well under 60ms in testing). On the
-Raspberry Pi, create a NetworkManager dispatcher script that adds the route
-with a lower `rto_min` whenever the relevant network interface comes up:
+To reduce this on a Raspberry Pi, create a NetworkManager dispatcher script. This
+specifies that the sepcific route to the AstroTrac360 should have a lower `rto_min` 
+(retransmission time):
+
 
 ```bash
 sudo tee /etc/NetworkManager/dispatcher.d/99-device-rto <<'EOF'
@@ -73,7 +85,7 @@ sudo chmod +x /etc/NetworkManager/dispatcher.d/99-device-rto
 **Before using this, change two things to match your own setup:**
 
 - `10.39.63.74` - replace with your mount's actual IP address (the same one
-  entered in TheSkyX's Serial Device Settings above).
+  entered in TheSky's Serial Device Settings above).
 - `wlan1` - replace with whichever network interface your Pi actually uses to
   reach the mount. Run `nmcli device status` (or `ip addr`) on the Pi to see
   the interface names available - it may be `wlan0` rather than `wlan1`,
@@ -87,3 +99,14 @@ IP shows the custom `rto_min`.
 This is a Pi/Linux-side network tuning change, not part of the driver itself -
 it doesn't require a new build, and it's safe to try independently of which
 driver version is installed.
+
+## Recommended: set TheSky's cross hair update interval to 500ms
+
+In TheSky's mount setting dialogue, set the cross hair update interval to 500ms. 
+The default is as soon as possible - in the AstroTrac360's case, this will be about
+300 times a second. That volume of traffic can cause communication problems about
+0.02% of the time. In turn this can cause unreliable pulse guide timings. Reducing 
+the cross hair update interval and reducing the retransmission time as suggested
+above will reduce the maximum time to send a command to 50ms. At 0.1 siderial
+this will result in maximum pulseguide error of less than 0.1" which is 
+insignificant.


### PR DESCRIPTION
## Summary
- Bump DRIVER_VERSION to 2.0 with a changelog entry summarizing the comms reliability work and the new firmware-level safety backstop.
- Add a "Key changes in 2.0" section to README.md.
- Fix typos, TheSkyX -> TheSky, clarify AstroTrac360's self-assigned IP, and reorder the two Recommended sections.